### PR TITLE
Restrict role selection by class

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,11 +53,26 @@
     .raid-roster {
       margin-top: 20px;
     }
-    .slot {
-      padding: 10px;
-      margin: 5px;
-      border-radius: 6px;
-      background-color: #3a3a5c;
+    .roster-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+    }
+    .roster-table th,
+    .roster-table td {
+      padding: 8px 12px;
+      border-bottom: 1px solid #555;
+      text-align: left;
+    }
+    .roster-table th {
+      background-color: rgba(255, 255, 255, 0.1);
+    }
+    .roster-table tbody tr:nth-child(even) {
+      background-color: rgba(255, 255, 255, 0.05);
+    }
+    .roster-table .primary-role {
+      background-color: rgba(255, 255, 255, 0.1);
+      font-weight: bold;
     }
     .btn {
       padding: 10px 20px;
@@ -158,6 +173,45 @@
       "Танк": "tank.png"
     };
 
+    const allowedRolesByClass = {
+      "Жрец": ["Хил", "ДД"],
+      "Друид": ["Хил", "ДД"],
+      "Некромант": ["Хил", "ДД"],
+      "Инженер": ["Сап", "ДД"],
+      "Бард": ["Сап", "ДД"],
+      "Паладин": ["Танк", "ДД"],
+      "Демонолог": ["Танк", "ДД"],
+      "Воин": ["Танк", "ДД"],
+      "Лучник": ["ДД"],
+      "Мистик": ["ДД"],
+      "Маг": ["ДД"]
+    };
+
+    function buildRoleOptions(arr, includeEmpty) {
+      const empty = includeEmpty ? '<option value="">—</option>' : '';
+      return empty + arr.map(r => `<option>${r}</option>`).join('');
+    }
+
+    function updateRoleOptions(id) {
+      const className = document.getElementById(`class-${id}`).value;
+      const allowed = allowedRolesByClass[className] || ["ДД"];
+      const roleSel = document.getElementById(`role-${id}`);
+      const role2Sel = document.getElementById(`role2-${id}`);
+      const role3Sel = document.getElementById(`role3-${id}`);
+
+      const prevRole = roleSel.value;
+      const prevRole2 = role2Sel.value;
+      const prevRole3 = role3Sel.value;
+
+      roleSel.innerHTML = buildRoleOptions(allowed, false);
+      role2Sel.innerHTML = buildRoleOptions(allowed, true);
+      role3Sel.innerHTML = buildRoleOptions(allowed, true);
+
+      if (allowed.includes(prevRole)) roleSel.value = prevRole;
+      if (prevRole2 && allowed.includes(prevRole2)) role2Sel.value = prevRole2;
+      if (prevRole3 && allowed.includes(prevRole3)) role3Sel.value = prevRole3;
+    }
+
     function roleOption(role, label) {
       const icon = roleIcons[role] ? `<img src="${roleIcons[role]}" class="role-icon">` : "";
       return `<span class='role-label'>${icon}${label}</span>`;
@@ -165,11 +219,36 @@
 
     function renderRoster(raid) {
       if (!raid.roster.length) return '<p>Пока никто не записался.</p>';
-      return raid.roster.map(p => {
-        const icon = classIcons[p.className] ? `<img class='class-icon' src="${classIcons[p.className]}" alt="${p.className}">` : "";
-        const roleIcon = roleIcons[p.role] ? `<img class='class-icon' src="${roleIcons[p.role]}" alt="${p.role}">` : "";
-        return `<div class='slot'>${icon}${p.name} — ${p.className} ${roleIcon}(осн: ${p.role}, доп: ${p.role2 || '-'}, крайний случай: ${p.role3 || '-'})</div>`;
+      const rows = raid.roster.map(p => {
+        const icon = classIcons[p.className] ? `<img class='class-icon' src="${classIcons[p.className]}" alt="${p.className}">` : '';
+        const roleIcon = roleIcons[p.role] ? `<img class='class-icon' src="${roleIcons[p.role]}" alt="${p.role}">` : '';
+        const role2Icon = roleIcons[p.role2] ? `<img class='class-icon' src="${roleIcons[p.role2]}" alt="${p.role2}">` : '';
+        const role3Icon = roleIcons[p.role3] ? `<img class='class-icon' src="${roleIcons[p.role3]}" alt="${p.role3}">` : '';
+        return `
+          <tr>
+            <td>${icon}${p.name}</td>
+            <td>${p.className}</td>
+            <td class='primary-role'>${roleIcon}${p.role}</td>
+            <td>${p.role2 ? `${role2Icon}${p.role2}` : '-'}</td>
+            <td>${p.role3 ? `${role3Icon}${p.role3}` : '-'}</td>
+          </tr>`;
       }).join('');
+
+      return `
+        <table class='roster-table'>
+          <thead>
+            <tr>
+              <th>Имя</th>
+              <th>Класс</th>
+              <th class='primary-role'>Осн. роль</th>
+              <th>Доп. роль</th>
+              <th>Крайний случай</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${rows}
+          </tbody>
+        </table>`;
     }
 
     function renderRaids() {
@@ -183,7 +262,7 @@
           <div class="form-section">
             <label>Имя: <input type="text" id="name-${raid.id}"></label>
             <label>Класс:
-              <select id="class-${raid.id}">
+              <select id="class-${raid.id}" onchange="updateRoleOptions(${raid.id})">
                 ${classes.map(c => `<option value="${c}">${c}</option>`).join('')}
               </select>
             </label>
@@ -212,6 +291,7 @@
           </div>
         `;
         raidsDiv.appendChild(raidEl);
+        updateRoleOptions(raid.id);
       });
     }
 
@@ -234,6 +314,11 @@
       const duplicate = currentRaid.roster.some(p => p.name.toLowerCase() === name.toLowerCase());
       if (duplicate) {
         return alert("Вы уже записаны в этот рейд.");
+      }
+
+      const allowed = allowedRolesByClass[className] || ["ДД"];
+      if (!allowed.includes(role) || (role2 && !allowed.includes(role2)) || (role3 && !allowed.includes(role3))) {
+        return alert("Этот класс не может выполнять выбранную роль.");
       }
 
       const payload = {


### PR DESCRIPTION
## Summary
- enforce valid class-role combinations in form
- reload role options based on chosen class
- validate class-role pairings on signup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854660c35c48331b3347acb3bfd91af