### PR TITLE
Allow custom roles and validate names

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,15 +54,21 @@
       margin-top: 20px;
     }
     .roster-table {
-      width: 100%;
+      width: auto;
       border-collapse: collapse;
       margin-top: 10px;
     }
     .roster-table th,
     .roster-table td {
-      padding: 8px 12px;
+      padding: 4px 8px;
       border-bottom: 1px solid #555;
       text-align: left;
+      width: 150px;
+      white-space: nowrap;
+    }
+    .roster-table th:first-child,
+    .roster-table td:first-child {
+      width: 190px;
     }
     .roster-table th {
       background-color: rgba(255, 255, 255, 0.1);
@@ -204,12 +210,12 @@
       const prevRole3 = role3Sel.value;
 
       roleSel.innerHTML = buildRoleOptions(allowed, false);
-      role2Sel.innerHTML = buildRoleOptions(allowed, true);
-      role3Sel.innerHTML = buildRoleOptions(allowed, true);
+      role2Sel.innerHTML = buildRoleOptions(roles, true);
+      role3Sel.innerHTML = buildRoleOptions(roles, true);
 
       if (allowed.includes(prevRole)) roleSel.value = prevRole;
-      if (prevRole2 && allowed.includes(prevRole2)) role2Sel.value = prevRole2;
-      if (prevRole3 && allowed.includes(prevRole3)) role3Sel.value = prevRole3;
+      role2Sel.value = prevRole2;
+      role3Sel.value = prevRole3;
     }
 
     function roleOption(role, label) {
@@ -260,7 +266,7 @@
         raidEl.innerHTML = `
           <h2>Рейд ${+raid.id + 1}</h2>
           <div class="form-section">
-            <label>Имя: <input type="text" id="name-${raid.id}"></label>
+            <label>Имя: <input type="text" id="name-${raid.id}" maxlength="16" minlength="3" pattern="[А-Яа-яЁё]{3,16}"></label>
             <label>Класс:
               <select id="class-${raid.id}" onchange="updateRoleOptions(${raid.id})">
                 ${classes.map(c => `<option value="${c}">${c}</option>`).join('')}
@@ -302,7 +308,9 @@
       const role2 = document.getElementById(`role2-${id}`).value;
       const role3 = document.getElementById(`role3-${id}`).value;
 
-      if (!name) return alert("Введите имя!");
+      if (!/^[А-Яа-яЁё]{3,16}$/.test(name)) {
+        return alert("Имя должно содержать от 3 до 16 русских букв без пробелов.");
+      }
 
       const currentRaid = raids.find(r => +r.id === +id);
       if (!currentRaid) return alert("Рейд не найден!");
@@ -317,7 +325,7 @@
       }
 
       const allowed = allowedRolesByClass[className] || ["ДД"];
-      if (!allowed.includes(role) || (role2 && !allowed.includes(role2)) || (role3 && !allowed.includes(role3))) {
+      if (!allowed.includes(role)) {
         return alert("Этот класс не может выполнять выбранную роль.");
       }
 


### PR DESCRIPTION
## Summary
- limit roster table width and cell sizes
- let additional roles ignore class restrictions
- enforce 3-16 Russian letters for names
- widen the name column in the roster
- set custom cursor image
- revert cursor customization (remove custom cursor, add pointer to buttons)

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685487065efc8331a84116e3e9cd6599