### PR TITLE
Add extra character info to raid roster

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,11 +276,12 @@
 
     function renderRoster(raid) {
       if (!raid.roster.length) return '<p>Пока никто не записался.</p>';
-      const rows = raid.roster.map(p => {
+        const rows = raid.roster.map(p => {
         const icon = classIcons[p.className] ? `<img class='class-icon' src="${classIcons[p.className]}" alt="${p.className}">` : '';
         const roleIcon = roleIcons[p.role] ? `<img class='class-icon' src="${roleIcons[p.role]}" alt="${p.role}">` : '';
         const role2Icon = roleIcons[p.role2] ? `<img class='class-icon' src="${roleIcons[p.role2]}" alt="${p.role2}">` : '';
         const role3Icon = roleIcons[p.role3] ? `<img class='class-icon' src="${roleIcons[p.role3]}" alt="${p.role3}">` : '';
+        const runes = typeof p.runes === 'string' ? p.runes : JSON.stringify(p.runes);
         return `
           <tr>
             <td>${icon}${p.name}</td>
@@ -288,6 +289,11 @@
             <td class='primary-role'>${roleIcon}${p.role}</td>
             <td>${p.role2 ? `${role2Icon}${p.role2}` : '-'}</td>
             <td>${p.role3 ? `${role3Icon}${p.role3}` : '-'}</td>
+            <td>${p.gearScore ?? '-'}</td>
+            <td>${runes || '-'}</td>
+            <td>${p.faction || '-'}</td>
+            <td>${p.guild || '-'}</td>
+            <td>${p.race || '-'}</td>
           </tr>`;
       }).join('');
 
@@ -300,6 +306,11 @@
               <th class='primary-role'>Осн. роль</th>
               <th>Доп. роль</th>
               <th>Крайний случай</th>
+              <th>GearScore</th>
+              <th>Runes</th>
+              <th>Faction</th>
+              <th>Guild</th>
+              <th>Race</th>
             </tr>
           </thead>
           <tbody>
@@ -419,9 +430,13 @@
       const data = await res.json();
       const grouped = {};
       data.forEach(row => {
-        const [name, className, role, role2, role3, raidId] = row;
+        const [name, className, role, role2, role3, raidId, gearScore, runes, faction, guild, race] = row;
+        let parsedRunes = runes;
+        if (typeof runes === 'string') {
+          try { parsedRunes = JSON.parse(runes); } catch (e) {}
+        }
         if (!grouped[raidId]) grouped[raidId] = [];
-        grouped[raidId].push({ name, className, role, role2, role3 });
+        grouped[raidId].push({ name, className, role, role2, role3, gearScore, runes: parsedRunes, faction, guild, race });
       });
 
       raids = Object.keys(grouped).map(id => ({ id, roster: grouped[id] }));


### PR DESCRIPTION
## Summary
- show more character details in raid roster table
- parse extended fields from Google Script when loading roster

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a8b1ed1d883318fc81427c23f9d2b