### PR TITLE
Fix runes serialization in roster

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,7 +426,7 @@
         server,
         raidId: id,
         gearScore: charInfo.gearScore,
-        runes: charInfo.runes,
+        runes: JSON.stringify(charInfo.runes),
         faction: charInfo.faction,
         guild: charInfo.guild,
         race: charInfo.race
@@ -446,9 +446,11 @@
       const grouped = {};
       data.forEach(row => {
         const [name, className, role, role2, role3, raidId, gearScore, runes, faction, guild, race] = row;
-        let parsedRunes = runes;
-        if (typeof runes === 'string') {
-          try { parsedRunes = JSON.parse(runes); } catch (e) {}
+        let parsedRunes;
+        try {
+          parsedRunes = JSON.parse(runes);
+        } catch (e) {
+          parsedRunes = runes;
         }
         if (!grouped[raidId]) grouped[raidId] = [];
         grouped[raidId].push({ name, className, role, role2, role3, gearScore, runes: parsedRunes, faction, guild, race });


### PR DESCRIPTION
## Summary
- stringify runes before sending to the server
- always JSON.parse runes when loading roster

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685a9552d64c8331a5b420a11250f507