### PR TITLE
Simplify roster columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,6 +244,7 @@
         }
 
         return {
+          level: data.level,
           gearScore: data.gear_score,
           runes,
           faction: data.faction,
@@ -293,7 +294,6 @@
         const roleIcon = roleIcons[p.role] ? `<img class='class-icon' src="${roleIcons[p.role]}" alt="${p.role}">` : '';
         const role2Icon = roleIcons[p.role2] ? `<img class='class-icon' src="${roleIcons[p.role2]}" alt="${p.role2}">` : '';
         const role3Icon = roleIcons[p.role3] ? `<img class='class-icon' src="${roleIcons[p.role3]}" alt="${p.role3}">` : '';
-        const runes = typeof p.runes === 'string' ? p.runes : JSON.stringify(p.runes);
         return `
           <tr>
             <td>${icon}${p.name}</td>
@@ -301,11 +301,10 @@
             <td class='primary-role'>${roleIcon}${p.role}</td>
             <td>${p.role2 ? `${role2Icon}${p.role2}` : '-'}</td>
             <td>${p.role3 ? `${role3Icon}${p.role3}` : '-'}</td>
+            <td>${p.level ?? '-'}</td>
             <td>${p.gearScore ?? '-'}</td>
-            <td>${runes || '-'}</td>
-            <td>${p.faction || '-'}</td>
             <td>${p.guild || '-'}</td>
-            <td>${p.race || '-'}</td>
+            <td>${p.faction || '-'}</td>
           </tr>`;
       }).join('');
 
@@ -318,11 +317,10 @@
               <th class='primary-role'>Осн. роль</th>
               <th>Доп. роль</th>
               <th>Крайний случай</th>
+              <th>Уровень</th>
               <th>GearScore</th>
-              <th>Runes</th>
-              <th>Faction</th>
-              <th>Guild</th>
-              <th>Race</th>
+              <th>Гильдия</th>
+              <th>Фракция</th>
             </tr>
           </thead>
           <tbody>
@@ -425,6 +423,7 @@
         role3,
         server,
         raidId: id,
+        level: charInfo.level,
         gearScore: charInfo.gearScore,
         runes: JSON.stringify(charInfo.runes),
         faction: charInfo.faction,
@@ -445,15 +444,21 @@
       const data = await res.json();
       const grouped = {};
       data.forEach(row => {
-        const [name, className, role, role2, role3, raidId, gearScore, runes, faction, guild, race] = row;
-        let parsedRunes;
-        try {
-          parsedRunes = JSON.parse(runes);
-        } catch (e) {
-          parsedRunes = runes;
+        if (row.length > 10) {
+          const [name, className, role, role2, role3, raidId, gearScore, runes, faction, guild, race] = row;
+          let parsedRunes;
+          try {
+            parsedRunes = JSON.parse(runes);
+          } catch (e) {
+            parsedRunes = runes;
+          }
+          if (!grouped[raidId]) grouped[raidId] = [];
+          grouped[raidId].push({ name, className, role, role2, role3, gearScore, runes: parsedRunes, faction, guild, race });
+        } else {
+          const [name, className, role, role2, role3, raidId, level, gearScore, guild, faction] = row;
+          if (!grouped[raidId]) grouped[raidId] = [];
+          grouped[raidId].push({ name, className, role, role2, role3, level, gearScore, guild, faction });
         }
-        if (!grouped[raidId]) grouped[raidId] = [];
-        grouped[raidId].push({ name, className, role, role2, role3, gearScore, runes: parsedRunes, faction, guild, race });
       });
 
       raids = Object.keys(grouped).map(id => ({ id, roster: grouped[id] }));


### PR DESCRIPTION
## Summary
- drop runes and race columns from roster table
- display character level in the roster
- reorder header columns

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685a9ecd39d48331bd0993393156f505