### PR TITLE
Add tertiary role to raid sign-up payload

### DIFF
--- a/index.html
+++ b/index.html
@@ -427,17 +427,18 @@
         return alert(msg);
       }
 
-      const payload = {
-        name,
-        className,
-        role,
-        role2,
-        raidId: id,
-        level: charInfo.level,
-        gearScore: charInfo.gearScore,
-        guild: charInfo.guild,
-        faction: charInfo.faction
-      };
+        const payload = {
+          name,
+          className,
+          role,
+          role2,
+          role3,
+          raidId: id,
+          level: charInfo.level,
+          gearScore: charInfo.gearScore,
+          guild: charInfo.guild,
+          faction: charInfo.faction
+        };
 
       await fetch(scriptURL, {
         method: 'POST',


### PR DESCRIPTION
## Summary
- include `role3` when sending sign-up data so tertiary role gets saved
- confirm `loadRoster` continues to parse 10-field rows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ab3862fdc8331946de59d86de7e2e