### PR TITLE
Fix fetch content type for roster POST

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,6 +442,7 @@
 
       await fetch(scriptURL, {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       });
 


### PR DESCRIPTION
## Summary
- ensure roster data is posted with `Content-Type: application/json`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ab54788f88331b641a2392f1db4ce