### PR TITLE
Improve roster loading error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,8 +480,21 @@
     }
 
     async function loadRoster() {
-      const res = await fetch(scriptURL);
-      const data = await res.json();
+      let data;
+      try {
+        const res = await fetch(scriptURL);
+        if (!res.ok) {
+          console.error('loadRoster', res.status, res.statusText);
+          alert('Не удалось загрузить список рейда.');
+          return;
+        }
+        data = await res.json();
+      } catch (e) {
+        console.error('loadRoster', e);
+        alert('Не удалось загрузить список рейда.');
+        return;
+      }
+
       const grouped = {};
       data.forEach(row => {
         if (row.length > 10) {


### PR DESCRIPTION
## Summary
- add error handling when fetching roster data

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(fails: command not found or no tests)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685ac16a3f1083318a989edafb7ce485