### PR TITLE
Handle non-OK signup response

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,6 +454,13 @@
         });
 
         console.log('Signup status:', res.status, res.statusText);
+        if (!res.ok) {
+          const text = await res.text();
+          console.error('Save failed', res.status, text);
+          alert('Не удалось сохранить данные в Google Sheets.');
+          return;
+        }
+
         const text = await res.text();
         console.log('Signup response text:', text);
         if (text.trim() !== 'OK') {


### PR DESCRIPTION
## Summary
- check `res.ok` in `joinRaid` before reading the body
- log the status/text and alert the user when saving fails

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ad79975888331a4366812c825eb01