### PR TITLE
Add error handling to raid API

### DIFF
--- a/raid-api.gs
+++ b/raid-api.gs
@@ -8,35 +8,49 @@ function withCors(output) {
 }
 
 function doGet() {
-  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(SHEET_NAME);
-  const rows = sheet.getDataRange().getValues();
-  rows.shift();
-  const out = ContentService.createTextOutput(JSON.stringify(rows))
-    .setMimeType(ContentService.MimeType.JSON);
-  return withCors(out);
+  try {
+    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(SHEET_NAME);
+    const rows = sheet.getDataRange().getValues();
+    rows.shift();
+    const out = ContentService.createTextOutput(JSON.stringify(rows))
+      .setMimeType(ContentService.MimeType.JSON);
+    return withCors(out);
+  } catch (err) {
+    const errorOut = ContentService.createTextOutput('ERROR')
+      .setMimeType(ContentService.MimeType.TEXT);
+    return withCors(errorOut);
+  }
 }
 
+
 function doPost(e) {
-  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(SHEET_NAME);
-  const data = JSON.parse(e.postData.contents);
-  const row = [
-    data.name,
-    data.className,
-    data.role,
-    data.role2,
-    data.role3,
-    data.raidId,
-    data.level || '',
-    data.gearScore || '',
-    data.guild || '',
-    data.faction || '',
-    data.server || ''
-  ];
-  sheet.appendRow(row);
-  const out = ContentService.createTextOutput('OK')
-    .setMimeType(ContentService.MimeType.TEXT);
-  return withCors(out);
+  try {
+    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(SHEET_NAME);
+    const data = JSON.parse(e.postData.contents);
+    const row = [
+      data.name,
+      data.className,
+      data.role,
+      data.role2,
+      data.role3,
+      data.raidId,
+      data.level || '',
+      data.gearScore || '',
+      data.guild || '',
+      data.faction || '',
+      data.server || ''
+    ];
+    sheet.appendRow(row);
+    const out = ContentService.createTextOutput('OK')
+      .setMimeType(ContentService.MimeType.TEXT);
+    return withCors(out);
+  } catch (err) {
+    const errorOut = ContentService.createTextOutput('ERROR')
+      .setMimeType(ContentService.MimeType.TEXT);
+    return withCors(errorOut);
+  }
 }
+
 
 function doOptions() {
   const out = ContentService.createTextOutput('');


### PR DESCRIPTION
## Summary
- wrap `doGet` and `doPost` logic in `try/catch`
- return `'ERROR'` when an exception occurs
- ensure every response is sent through `withCors`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ae8f49d908331a9d91b1a5277cdf9