### PR TITLE
Add README for deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Allods Raid Signup
+
+This repository contains a static site for organizing raid signups in the game *Allods Online* along with a Google Apps Script backend.
+
+## Deploying the Google Apps Script
+
+1. Open [`raid-api.gs`](raid-api.gs) in [Google Apps Script](https://script.google.com/).
+2. Click **Deploy → New deployment**.
+3. Choose **Web app** as the deployment type.
+4. Under **Execute as**, select **Me**.
+5. Under **Who has access**, select **Anyone** (or **Anyone, even anonymous**).
+6. Deploy and authorize if prompted, then copy the **Web app URL** that is shown.
+
+## Updating `index.html`
+
+1. Open [`index.html`](index.html) and locate the line containing `scriptURL`.
+   It looks like:
+   ```html
+   const scriptURL = 'https://script.google.com/macros/......';
+   ```
+2. Replace the placeholder URL with the **Web app URL** from the deployment step.
+3. Save the file and commit the change.
+
+## Hosting the Site
+
+The project only requires a static host for `index.html` and its assets. One option is **GitHub Pages**:
+
+1. Push the repository to GitHub.
+2. In your repository settings, enable **GitHub Pages** and choose the branch and folder containing `index.html` (typically the root).
+3. After GitHub builds the site, visit the provided Pages URL to access the raid signup page.
+
+Any static hosting service (Netlify, Vercel, etc.) can be used as long as the final `index.html` references the deployed Apps Script URL.


### PR DESCRIPTION
## Summary
- add a README that explains how to deploy `raid-api.gs` as a web app
- document how to update `scriptURL` in `index.html`
- describe how to host the static site (for example via GitHub Pages)

## Testing
- `npm test` *(fails: could not find package.json)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_685aead48f188331a8477e7bcad75b2c