### PR TITLE
Fix CORS preflight by removing JSON header

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,7 +450,6 @@
         const res = await fetch(scriptURL, {
           method: 'POST',
           mode: 'cors',
-          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
         });
 


### PR DESCRIPTION
## Summary
- remove `Content-Type: application/json` header from the signup request so that the browser doesn't send a preflight OPTIONS request which Google Apps Script cannot handle

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685aecd99bc48331a1b048df39b8026b