### PR TITLE
Prevent duplicate nicknames

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,6 +397,14 @@
       const currentRaid = raids.find(r => +r.id === +id);
       if (!currentRaid) return alert("Рейд не найден!");
 
+      // Disallow using the same character name across all raids
+      const nameTaken = raids.some(r =>
+        r.roster.some(p => p.name.toLowerCase() === name.toLowerCase())
+      );
+      if (nameTaken) {
+        return alert('Игрок с таким именем уже записан.');
+      }
+
       if (currentRaid.roster.length >= MAX_PLAYERS) {
         return alert("Этот рейд уже заполнен (12 игроков).");
       }


### PR DESCRIPTION
## Summary
- disallow signing up with a name that already exists in any raid roster

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685af21e56248331a25da9adaa78783f