### PR TITLE
Fix closed raid lookup

### DIFF
--- a/script.js
+++ b/script.js
@@ -307,7 +307,7 @@ async function joinRaid(id) {
     return alert('Выберите сервер.');
   }
 
-  const currentRaid = raids.find(r => +r.id === +id);
+  const currentRaid = raids.find(r => String(r.id) === String(id));
   if (!currentRaid) return alert("Рейд не найден!");
 
   // Disallow using the same character name across all raids


### PR DESCRIPTION
## Summary
- ensure `joinRaid` matches raid IDs using strings

## Testing
- `node - <<'EOF'
const raids = [{id: 'abc123', roster: []}];
const id = 'abc123';
const currentRaid = raids.find(r => String(r.id) === String(id));
console.log('found raid', currentRaid);
EOF`
- `node script.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68619e8c827c833194f5fa85448260ec