### PR TITLE
Fix raid id string comparison and return JSON from API

### DIFF
--- a/raid-api.gs
+++ b/raid-api.gs
@@ -12,14 +12,16 @@ function doGet() {
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(SHEET_NAME);
     const rows = sheet.getDataRange().getValues();
     rows.shift(); // убираем заголовки
+    const payload = { status: 'ok', data: rows };
     return addCors(
-      ContentService.createTextOutput(JSON.stringify(rows))
+      ContentService.createTextOutput(JSON.stringify(payload))
         .setMimeType(ContentService.MimeType.JSON)
     );
   } catch (err) {
+    const payload = { status: 'error', message: String(err) };
     return addCors(
-      ContentService.createTextOutput('ERROR')
-        .setMimeType(ContentService.MimeType.TEXT)
+      ContentService.createTextOutput(JSON.stringify(payload))
+        .setMimeType(ContentService.MimeType.JSON)
     );
   }
 }
@@ -52,21 +54,21 @@ function doPost(e) {
 
     sheet.appendRow(row);
     return addCors(
-      ContentService.createTextOutput('OK')
-        .setMimeType(ContentService.MimeType.TEXT)
+      ContentService.createTextOutput(JSON.stringify({ status: 'ok' }))
+        .setMimeType(ContentService.MimeType.JSON)
     );
   } catch (err) {
+    const payload = { status: 'error', message: String(err) };
     return addCors(
-      ContentService.createTextOutput('ERROR')
-        .setMimeType(ContentService.MimeType.TEXT)
+      ContentService.createTextOutput(JSON.stringify(payload))
+        .setMimeType(ContentService.MimeType.JSON)
     );
   }
 }
 
 function doOptions() {
-  return ContentService.createTextOutput('')
-    .setMimeType(ContentService.MimeType.TEXT)
-    .setHeader('Access-Control-Allow-Origin', '*')
-    .setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-    .setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return addCors(
+    ContentService.createTextOutput('')
+      .setMimeType(ContentService.MimeType.TEXT)
+  );
 }

--- a/script.js
+++ b/script.js
@@ -307,7 +307,7 @@ async function joinRaid(id) {
     return alert('Выберите сервер.');
   }
 
-  const currentRaid = raids.find(r => +r.id === +id);
+  const currentRaid = raids.find(r => String(r.id) === String(id));
   if (!currentRaid) return alert("Рейд не найден!");
 
   // Disallow using the same character name across all raids


### PR DESCRIPTION
## Summary
- match raid IDs as strings in `joinRaid`
- return JSON payloads from `raid-api.gs`

## Testing
- `node - <<'EOF'
const raids = [{id: 'abc123', roster: []}];
const id = 'abc123';
const currentRaid = raids.find(r => String(r.id) === String(id));
console.log('found raid', currentRaid);
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68619e8c827c833194f5fa85448260ec