### PR TITLE
Handle JSON responses and CORS

### DIFF
--- a/raid-api.gs
+++ b/raid-api.gs
@@ -12,14 +12,16 @@ function doGet() {
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(SHEET_NAME);
     const rows = sheet.getDataRange().getValues();
     rows.shift(); // убираем заголовки
+    const payload = { status: 'ok', data: rows };
     return addCors(
-      ContentService.createTextOutput(JSON.stringify(rows))
+      ContentService.createTextOutput(JSON.stringify(payload))
         .setMimeType(ContentService.MimeType.JSON)
     );
   } catch (err) {
+    const payload = { status: 'error', message: String(err) };
     return addCors(
-      ContentService.createTextOutput('ERROR')
-        .setMimeType(ContentService.MimeType.TEXT)
+      ContentService.createTextOutput(JSON.stringify(payload))
+        .setMimeType(ContentService.MimeType.JSON)
     );
   }
 }
@@ -52,21 +54,21 @@ function doPost(e) {
 
     sheet.appendRow(row);
     return addCors(
-      ContentService.createTextOutput('OK')
-        .setMimeType(ContentService.MimeType.TEXT)
+      ContentService.createTextOutput(JSON.stringify({ status: 'ok' }))
+        .setMimeType(ContentService.MimeType.JSON)
     );
   } catch (err) {
+    const payload = { status: 'error', message: String(err) };
     return addCors(
-      ContentService.createTextOutput('ERROR')
-        .setMimeType(ContentService.MimeType.TEXT)
+      ContentService.createTextOutput(JSON.stringify(payload))
+        .setMimeType(ContentService.MimeType.JSON)
     );
   }
 }
 
 function doOptions() {
-  return ContentService.createTextOutput('')
-    .setMimeType(ContentService.MimeType.TEXT)
-    .setHeader('Access-Control-Allow-Origin', '*')
-    .setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-    .setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return addCors(
+    ContentService.createTextOutput(JSON.stringify({ status: 'ok' }))
+      .setMimeType(ContentService.MimeType.JSON)
+  );
 }


### PR DESCRIPTION
## Summary
- use JSON payloads for GET, POST, and OPTIONS in `raid-api.gs`
- send JSON from frontend and parse JSON responses
- add `Content-Type` header when posting signup data

## Testing
- `node - <<'EOF'
const raids = [{id: 'abc123', roster: []}, {id: 5, roster: []}];
const id = 'abc123';
const found = raids.find(r => String(r.id) === String(id));
console.log(found);
EOF`
- `node - <<'EOF'
const responseJson = { status: 'ok', data: [[1,2],[3,4]] };
const data = responseJson.data;
console.log(Array.isArray(data), data.length);
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68619e8c827c833194f5fa85448260ec