### PR TITLE
Fix CORS documentation and adjust API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Edit the `scriptURL` constant at the top of **script.js** and replace the curren
 const scriptURL = 'YOUR_WEB_APP_URL_HERE';
 ```
 
+### CORS considerations
+
+Google Apps Script doesn't expose an `OPTIONS` handler, so preflight
+requests won't reach your code. Avoid sending custom request headers
+(like `Content-Type: application/json`) from the frontend so the browser
+makes a simple CORS request. The included `script.js` already omits this
+header when calling the Apps Script.
+
 ## Spreadsheet setup
 
 `raid-api.gs` expects a sheet named `Лист1` in the active spreadsheet. If your sheet has a different name, update the `SHEET_NAME` constant in **raid-api.gs** accordingly:

--- a/raid-api.gs
+++ b/raid-api.gs
@@ -4,7 +4,8 @@ function addCors(output) {
   return output
     .setHeader('Access-Control-Allow-Origin', '*')
     .setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-    .setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    .setHeader('Access-Control-Allow-Headers', 'Content-Type')
+    .setHeader('Vary', 'Origin');
 }
 
 function doGet() {
@@ -66,6 +67,10 @@ function doPost(e) {
   }
 }
 
+// Note: Apps Script does not route HTTP OPTIONS requests to this handler.
+// Preflight requests will therefore not reach the script. Instead of
+// relying on doOptions(), avoid custom headers in the frontend so that
+// the browser sends a "simple" request without a preflight.
 function doOptions() {
   return addCors(
     ContentService.createTextOutput('')

--- a/script.js
+++ b/script.js
@@ -382,10 +382,10 @@ async function joinRaid(id) {
       return;
     }
 
-    const text = await res.text();
-    console.log('Signup response text:', text);
-    if (text.trim() !== 'OK') {
-      console.error('Save failed', res.status, text);
+    const data = await res.json();
+    console.log('Signup response:', data);
+    if (!data || data.status !== 'ok') {
+      console.error('Save failed', res.status, JSON.stringify(data));
       alert('Не удалось сохранить данные в Google Sheets.');
       return;
     }


### PR DESCRIPTION
## Summary
- document why OPTIONS can't be used with Apps Script
- show how to avoid preflight CORS requests
- expose `Vary: Origin` in the Apps Script response
- handle JSON response from the Apps Script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862ef3a5af883318a9448a52ec7acc1