### PR TITLE
Implement dungeon-based raid filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ GearScore
 Guild
 Faction
 Server
+Dungeon
 Ensure the sheet contains at least these columns before calling appendRow. If getMaxColumns() is lower than the payload length, insert new columns with insertColumnsAfter to avoid data loss.
 Update index.html
 

--- a/raid-api.gs
+++ b/raid-api.gs
@@ -36,7 +36,8 @@ function doPost(e) {
       data.gearScore || '',
       data.guild || '',
       data.faction || '',
-      data.server || ''
+      data.server || '',
+      data.dungeon || ''
     ];
 
     // Гарантируем нужное количество столбцов


### PR DESCRIPTION
## Summary
- extend README to include `Dungeon` column for the spreadsheet
- store dungeon information in `raid-api.gs`
- filter rosters and squads by server, faction and dungeon in `script.js`
- attach metadata when creating and joining raids

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68664318e4848331a03f7263c6202fe1