### PR TITLE
Fix raid loading and dungeon saving

### DIFF
--- a/script.js
+++ b/script.js
@@ -517,6 +517,7 @@ function onSelect(step, id) {
     sel.faction = id;
     document.getElementById('bgVideo').style.display = 'none';
     loadSquads();
+    loadRoster();
     showStep(4);
   }
 }
@@ -579,6 +580,7 @@ function joinByCode() {
       }
       sel.server = row[10];
       sel.faction = row[9] === 'Лига' ? 'league' : 'empire';
+      sel.dungeon = row[11];
       showStep(4);
       loadRoster().then(() => {
         const el = document.querySelector(`#raids .raid-container[data-id='${code}']`);


### PR DESCRIPTION
## Summary
- load rosters after selecting faction so existing raids appear
- save the dungeon when joining by code so Sheets capture the dungeon

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68664f7f4b848331b84aa927462ba35d