### PR TITLE
Hide raid form until join click and require code for closed squads

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,6 +30,10 @@ h1, h2 {
   margin-bottom: 20px;
 }
 
+.code-section {
+  margin-bottom: 20px;
+}
+
 label, select, input {
   display: block;
   margin: 8px 0;


### PR DESCRIPTION
## Summary
- removed localStorage based code reveal logic
- added `code-section` step before signup for closed squads
- hide signup form until code validated
- small CSS tweak for the new code section

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68666c4827048331902d70178df63882