### PR TITLE
Display guild above player names

### DIFF
--- a/script.js
+++ b/script.js
@@ -197,14 +197,13 @@ function renderRoster(raid) {
     const tertiary = p.role3 ? roleOption(p.role3, p.role3) : '-';
     return `
       <tr>
-        <td>${icon}${p.name}</td>
+        <td>${icon}${p.guild ? `<sup class="guild-sup">${p.guild}</sup>` : ''}${p.name}</td>
         <td>${p.className}</td>
         <td class='primary-role'>${primary}</td>
         <td>${secondary}</td>
         <td>${tertiary}</td>
         <td>${p.level ?? '-'}</td>
         <td>${p.gearScore ?? '-'}</td>
-        <td>${p.guild || '-'}</td>
         <td>${p.faction || '-'}</td>
       </tr>`;
   }).join('');
@@ -220,7 +219,6 @@ function renderRoster(raid) {
           <th>Крайний случай</th>
           <th>Уровень</th>
           <th>GearScore</th>
-          <th>Гильдия</th>
           <th>Фракция</th>
         </tr>
       </thead>

--- a/style.css
+++ b/style.css
@@ -122,6 +122,11 @@ label, select, input {
   margin-right: 6px;
 }
 
+.guild-sup {
+  font-size: 0.7em;
+  margin-right: 2px;
+}
+
 .footer {
   margin-top: 40px;
   text-align: center;


### PR DESCRIPTION
## Summary
- show guild as a superscript above each player's name
- remove the separate "Guild" column from the roster table
- style guild superscripts via CSS

## Testing
- `node --check script.js` *(fails: node not installed)*
- `apt-get update` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b992c194508331a9670e3d6554e09b