### PR TITLE
Enable navigation and update styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -542,12 +542,33 @@ loadRoster();
 
 const progress = [document.getElementById('p1'), document.getElementById('p2'), document.getElementById('p3'), document.getElementById('p4')];
 let sel = { server: null, dungeon: null, faction: null };
+let currentStep = 1;
 function showStep(n) {
+  currentStep = n;
   ['step1','step2','step3','step4'].forEach((id,i) => {
     document.getElementById(id).style.display = i === n-1 ? 'block' : 'none';
     progress[i].classList.toggle('active', i <= n-1);
   });
+  document.getElementById('bgVideo').style.display = n < 4 ? 'block' : 'none';
 }
+progress.forEach((el, i) => {
+  el.addEventListener('click', () => {
+    if (i < currentStep - 1) {
+      if (i === 0) {
+        sel = { server: null, dungeon: null, faction: null };
+      } else if (i === 1) {
+        sel.dungeon = null;
+        sel.faction = null;
+      } else if (i === 2) {
+        sel.faction = null;
+      }
+      showStep(i + 1);
+    }
+  });
+});
+document.getElementById('homeTitle').addEventListener('click', () => {
+  window.location.href = 'index.html';
+});
 function onSelect(step, id) {
   if (step === 1) {
     sel.server = id;

--- a/style.css
+++ b/style.css
@@ -19,6 +19,10 @@ h1, h2 {
   color: #ffc107;
 }
 
+#homeTitle {
+  cursor: pointer;
+}
+
 .raid-container {
   margin-bottom: 40px;
   padding: 20px;
@@ -156,10 +160,10 @@ body,html{
 #bgVideo{position:fixed;top:0;left:0;width:100%;height:100%;object-fit:cover;filter:blur(4px);z-index:-1}
 .step{display:none;text-align:center;margin-top:40px}
 .servers img,.dungeons img,.factions img{width:150px;height:150px;cursor:pointer;margin:10px;border-radius:8px;border:2px solid transparent;}
-.servers div,.dungeons div,.factions div{display:inline-block;text-align:center}
+.servers div,.dungeons div,.factions div{display:inline-block;text-align:center;color:#ffc107}
 .progress{position:fixed;top:10px;left:50%;transform:translateX(-50%);display:flex;gap:10px;z-index:10}
 .progress div{width:20px;height:20px;border-radius:50%;background:#777}
-.progress .active{background:#28a745}
+.progress .active{background:#28a745;cursor:pointer}
 #squads{padding:20px;overflow-y:auto;height:100%;background:rgba(0,0,0,0.6)}
 .squad{background:#222;margin:10px;padding:10px;border-radius:6px}
 .squad.open .type{color:lime}


### PR DESCRIPTION
## Summary
- Allow clicking the site title to return home
- Enable progress indicators to navigate back to earlier steps
- Match selection text color to the main title and improve pointer cues

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba01b5ab7c83319072ae2ee42f1058