### PR TITLE
Ensure developer button sticks to page bottom

### DIFF
--- a/style.css
+++ b/style.css
@@ -134,8 +134,9 @@ label, select, input {
 }
 
 .footer {
-  margin-top: 40px;
+  margin-top: auto;
   text-align: center;
+  padding: 20px 0;
 }
 
 .developer-link {
@@ -153,11 +154,16 @@ label, select, input {
 body,html{
   margin:0;
   padding:0;
-  min-height:100%;
+  min-height:100vh;
   font-family:'Allods West',Arial,sans-serif;
   color:#fff;
   overflow-x:hidden;
   overflow-y:auto;
+}
+
+body {
+  display:flex;
+  flex-direction:column;
 }
 #bgVideo{position:fixed;top:0;left:0;width:100%;height:100%;object-fit:cover;filter:blur(4px);z-index:-1}
 .step{display:none;text-align:center;margin-top:40px}


### PR DESCRIPTION
## Summary
- keep developer link pinned to bottom using flexbox layout

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bac35b0f288331a686f6310ac99277