### PR TITLE
Prevent duplicate character entries within the same squad

### DIFF
--- a/raid-api.gs
+++ b/raid-api.gs
@@ -24,12 +24,12 @@ function doPost(e) {
   try {
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(SHEET_NAME);
     const data = JSON.parse(e.postData.contents);
-
     const raidIdStr = String(data.raidId);
+    const rows = sheet.getDataRange().getValues();
+    rows.shift();
+
     if (raidIdStr.length > 2) {
       // Closed raid code: ensure it is unique across all raids.
-      const rows = sheet.getDataRange().getValues();
-      rows.shift();
       const conflict = rows.some(r => String(r[5]) === raidIdStr && (
         String(r[10]) !== String(data.server) ||
         String(r[9]) !== String(data.faction) ||
@@ -40,6 +40,21 @@ function doPost(e) {
         return ContentService.createTextOutput(JSON.stringify(payload))
           .setMimeType(ContentService.MimeType.JSON);
       }
+    }
+
+    const duplicate = rows.some(r => {
+      if (String(r[5]) !== raidIdStr) return false;
+      const sameName = String(r[0]).toLowerCase() === String(data.name).toLowerCase();
+      if (!sameName) return false;
+      if (r[10] && data.server) {
+        return String(r[10]) === String(data.server);
+      }
+      return true;
+    });
+    if (duplicate) {
+      const payload = { status: 'error', message: 'duplicate_character' };
+      return ContentService.createTextOutput(JSON.stringify(payload))
+        .setMimeType(ContentService.MimeType.JSON);
     }
 
     const row = [

--- a/script.js
+++ b/script.js
@@ -340,14 +340,6 @@ async function joinRaid(id) {
   const currentRaid = raids.find(r => String(r.id) === String(id));
   if (!currentRaid) return alert("Рейд не найден!");
 
-  // Disallow using the same character name across all raids
-  const nameTaken = raids.some(r =>
-    r.roster.some(p => p.name.toLowerCase() === name.toLowerCase())
-  );
-  if (nameTaken) {
-    return alert('Игрок с таким именем уже записан.');
-  }
-
   if (currentRaid.roster.length >= MAX_PLAYERS) {
     return alert("Этот рейд уже заполнен (12 игроков).");
   }


### PR DESCRIPTION
## Summary
- Remove cross-raid character uniqueness check on the client, allowing the same character in multiple raids
- Add server-side validation to block duplicate character signups within a single raid

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5ec3987883318e1b4a91b38e16b9