### PR TITLE
Highlight selectable elements on hover and click

### DIFF
--- a/script.js
+++ b/script.js
@@ -595,9 +595,15 @@ function onSelect(step, id) {
     showStep(4);
   }
 }
-document.querySelectorAll('.servers div').forEach(el => el.onclick = () => onSelect(1, el.dataset.id));
-document.querySelectorAll('.dungeons div').forEach(el => el.onclick = () => onSelect(2, el.dataset.id));
-document.querySelectorAll('.factions div').forEach(el => el.onclick = () => onSelect(3, el.dataset.id));
+document.querySelectorAll('.servers div').forEach(el => {
+  el.addEventListener('click', () => onSelect(1, el.dataset.id));
+});
+document.querySelectorAll('.dungeons div').forEach(el => {
+  el.addEventListener('click', () => onSelect(2, el.dataset.id));
+});
+document.querySelectorAll('.factions div').forEach(el => {
+  el.addEventListener('click', () => onSelect(3, el.dataset.id));
+});
 function loadSquads() {
   document.getElementById('squads').innerHTML = '<p>Загрузка отрядов...</p>';
   fetch(scriptURL, { mode: 'cors' })

--- a/style.css
+++ b/style.css
@@ -167,8 +167,10 @@ body {
 }
 #bgVideo{position:fixed;top:0;left:0;width:100%;height:100%;object-fit:cover;filter:blur(4px);z-index:-1}
 .step{display:none;text-align:center;margin-top:40px}
-.servers img,.dungeons img,.factions img{width:150px;height:150px;cursor:pointer;margin:10px;border-radius:8px;border:2px solid transparent;}
-.servers div,.dungeons div,.factions div{display:inline-block;text-align:center;color:#ffc107}
+.servers img,.dungeons img,.factions img{width:150px;height:150px;margin:10px;border-radius:8px;border:2px solid transparent;}
+.servers div,.dungeons div,.factions div{display:inline-block;text-align:center;color:#ffc107;cursor:pointer}
+.servers div:hover img,.dungeons div:hover img,.factions div:hover img{border-color:#ffc107}
+.servers div:active img,.dungeons div:active img,.factions div:active img{border-color:#28a745}
 .progress{position:fixed;top:10px;left:50%;transform:translateX(-50%);display:flex;gap:10px;z-index:10}
 .progress div{width:20px;height:20px;border-radius:50%;background:#777}
 .progress .active{background:#28a745;cursor:pointer}


### PR DESCRIPTION
## Summary
- Outline selection options in yellow on hover and briefly in green while clicked
- Simplify click handlers to avoid lingering green borders

## Testing
- `npm test` *(fails: command not found: npm; unable to install due to 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd62d1add48331a293cca250aed5fb