### PR TITLE
Add usage hints and site summary toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   </head>
 <body>
   <h1><a href="index.html" id="homeTitle">Рейды Аллоды Онлайн</a></h1>
+  <button id="summaryBtn" class="summary-toggle" onclick="toggleSummary()">О сайте</button>
   <div class="music-controls">
     <button class="music-toggle" onclick="prevTrack()" id="prevBtn">&#9664;</button>
     <button class="music-toggle" onclick="toggleMusic()" id="musicBtn">Выключить музыку</button>
@@ -20,9 +21,10 @@
     <div id="p3"></div>
     <div id="p4"></div>
   </div>
-  <button id="joinCodeBtn" class="join-code-btn" onclick="joinByCode()">Присоединиться по коду</button>
+  <button id="joinCodeBtn" class="join-code-btn" onclick="joinByCode()" title="Вступить в отряд по коду">Присоединиться по коду</button>
   <div id="step1" class="step" style="display:block">
     <h2>Выберите сервер</h2>
+    <p class="hint">Кликните по значку сервера, чтобы продолжить.</p>
     <div class="servers">
       <div data-id="1"><img src="battles_icon.png"><br>Нить судьбы</div>
       <div data-id="2"><img src="battles_icon.png"><br>Молодая Гвардия</div>
@@ -33,6 +35,7 @@
   </div>
   <div id="step2" class="step">
     <h2>Выберите данж</h2>
+    <p class="hint">Выберите подземелье, в котором хотите провести рейд.</p>
     <div class="dungeons">
       <div data-id="nihaza"><img src="Iranoh_Kania_Female_5.png"><br>Цитадель Нихаза</div>
       <div data-id="sadrok"><img src="W_lvp6A8wTpf-f0zLFy4uQ(1).png"><br>Дворец Садрок</div>
@@ -41,6 +44,7 @@
   </div>
   <div id="step3" class="step">
     <h2>Выберите фракцию</h2>
+    <p class="hint">Определите фракцию вашего персонажа.</p>
     <div class="factions">
       <div data-id="league"><img src="liga.png"><br>Лига</div>
       <div data-id="empire"><img src="imperia.png"><br>Империя</div>
@@ -48,9 +52,15 @@
   </div>
   <div id="step4" class="step">
     <h2>Отряды</h2>
+    <p class="hint">Просматривайте доступные отряды или создайте свой собственный.</p>
     <div id="squads"></div>
     <div id="raids"></div>
-    <button class="btn btn-admin" onclick="createRaid()">+ Создать новый рейд</button>
+    <button class="btn btn-admin" onclick="createRaid()" title="Создать новый рейд">+ Создать новый рейд</button>
+  </div>
+
+  <div id="siteSummary" class="summary" style="display:none">
+    <h2>О сайте</h2>
+    <p>Этот сайт помогает организовывать и вступать в рейды в игре «Аллоды Онлайн». Выберите сервер, данж и фракцию, чтобы увидеть список доступных отрядов, присоединиться к ним или создать собственный рейд.</p>
   </div>
 
     <div class="footer">

--- a/script.js
+++ b/script.js
@@ -669,3 +669,11 @@ function joinByCode() {
     .catch(() => alert('Ошибка поиска отряда'));
 }
 
+function toggleSummary() {
+  const summary = document.getElementById('siteSummary');
+  const btn = document.getElementById('summaryBtn');
+  const visible = summary.style.display === 'block';
+  summary.style.display = visible ? 'none' : 'block';
+  btn.textContent = visible ? 'О сайте' : 'Скрыть описание';
+}
+

--- a/style.css
+++ b/style.css
@@ -189,3 +189,35 @@ body {
   cursor:pointer;
 }
 
+.summary-toggle{
+  position:fixed;
+  top:20px;
+  left:20px;
+  z-index:20;
+  padding:10px 20px;
+  background:#ffc107;
+  color:#000;
+  border:none;
+  border-radius:6px;
+  cursor:pointer;
+}
+
+.summary{
+  position:fixed;
+  top:80px;
+  left:50%;
+  transform:translateX(-50%);
+  background:rgba(0,0,0,0.8);
+  padding:20px;
+  border-radius:8px;
+  max-width:600px;
+  z-index:20;
+  text-align:left;
+}
+
+.hint{
+  font-size:14px;
+  color:#ccc;
+  margin-bottom:10px;
+}
+


### PR DESCRIPTION
## Summary
- add help text for key steps to guide raid selection and creation
- provide toggleable site summary explaining the project
- style and script support for summary overlay

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd945e617883319dd3a1e74fb140ff