### PR TITLE
Validate character server and faction before raid signup

### DIFF
--- a/script.js
+++ b/script.js
@@ -375,6 +375,11 @@ async function joinRaid(id) {
     return alert(msg);
   }
 
+  const expectedFaction = sel.faction === 'league' ? 'Лига' : 'Империя';
+  if (String(server) !== String(sel.server) || charInfo.faction !== expectedFaction) {
+    return alert('Сервер или фракция персонажа не совпадают с выбранными. Запись невозможна.');
+  }
+
   const payload = {
     name,
     className,


### PR DESCRIPTION
## Summary
- prevent players from registering characters from another server or faction by comparing fetched character data against selected raid context

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bda065fb8483319c783482fb045f7d