### PR TITLE
feat: add reminder for closed raid code

### DIFF
--- a/script.js
+++ b/script.js
@@ -258,8 +258,14 @@ function renderRaids() {
     // records may not, so we infer it from the identifier.
     const isClosed = raid.closed ?? /^[A-Za-z0-9!@#$]+$/.test(raid.id);
     const typeLabel = isClosed ? 'Закрытый' : 'Открытый';
+    const noteHtml = isClosed
+      ? `<span class="closed-note">Сохраните этот код! Для просмотра и вступления в данный закрытый отряд, понадобится его обязательный ввод</span>`
+      : '';
     raidEl.innerHTML = `
-      <h2>Отряд ${raid.id} (${typeLabel})</h2>
+      <div class="raid-header">
+        <h2>Отряд ${raid.id} (${typeLabel})</h2>
+        ${noteHtml}
+      </div>
       <div class="form-section">
         <label>Имя: <input type="text" id="name-${raid.id}" maxlength="16" minlength="3" pattern="[А-Яа-яЁё]{3,16}"></label>
         <label>Класс:

--- a/style.css
+++ b/style.css
@@ -32,6 +32,19 @@ h1, h2 {
   border-radius: 10px;
 }
 
+.raid-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+}
+
+.closed-note {
+  font-size: 14px;
+  color: #ffc107;
+  text-align: right;
+}
+
 .form-section {
   margin-bottom: 20px;
 }


### PR DESCRIPTION
## Summary
- show reminder to save the code when viewing a closed squad
- style closed squad header and note

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bda578242483319a31bb94a380adac